### PR TITLE
feat(auth): implement email verification with SMTP and generic ApiRes…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,11 @@
   			<artifactId>dotenv-java</artifactId>
  			 <version>3.0.0</version>
 		</dependency>
-		
+		<!--jakarta mail-->
+		<dependency>
+    		<groupId>org.springframework.boot</groupId>
+    		<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
 
 	</dependencies>
 	<dependencyManagement>

--- a/src/main/java/com/finscope/fraudscope/authentication/config/SecurityConfig.java
+++ b/src/main/java/com/finscope/fraudscope/authentication/config/SecurityConfig.java
@@ -32,6 +32,8 @@ public class SecurityConfig {
 
 	public static final String LOGIN = "/api/auth/login";
 
+	public static final String ACCOUNT_VERIFY = "/api/auth/verify";
+	
 	@Bean
 	 SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
 
@@ -39,7 +41,7 @@ public class SecurityConfig {
 			.csrf(csrf -> csrf.disable())
 			.securityContext(securityContext -> securityContext.requireExplicitSave(false))
 			.authorizeHttpRequests(authorize -> authorize
-				.requestMatchers(REGISTER, LOGIN).permitAll()
+				.requestMatchers(REGISTER, LOGIN,ACCOUNT_VERIFY).permitAll()
 				.anyRequest().authenticated()
 			)
 			.exceptionHandling(handling -> handling

--- a/src/main/java/com/finscope/fraudscope/authentication/service/AuthService.java
+++ b/src/main/java/com/finscope/fraudscope/authentication/service/AuthService.java
@@ -7,4 +7,10 @@ public interface AuthService {
 
 	AuthReponse register(RegisterRequest registerRequest);
 	
+	
+	
+	
+	
+	
+	
 }

--- a/src/main/java/com/finscope/fraudscope/authentication/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/finscope/fraudscope/authentication/service/impl/AuthServiceImpl.java
@@ -16,6 +16,9 @@ import com.finscope.fraudscope.authentication.refreshtoken.entity.RefreshToken;
 import com.finscope.fraudscope.authentication.refreshtoken.repository.RefreshTokenRepository;
 import com.finscope.fraudscope.authentication.repository.AuthUserRepository;
 import com.finscope.fraudscope.authentication.service.AuthService;
+import com.finscope.fraudscope.authentication.verification.enums.TokenPurpose;
+import com.finscope.fraudscope.authentication.verification.token.entity.VerificationToken;
+import com.finscope.fraudscope.authentication.verification.token.service.VerificationTokenService;
 import com.finscope.fraudscope.authorization.role.entity.Role;
 import com.finscope.fraudscope.authorization.role.repository.RoleRepository;
 import com.finscope.fraudscope.authorization.roleuser.entity.RoleUser;
@@ -36,6 +39,8 @@ public class AuthServiceImpl implements AuthService{
 	private final RefreshTokenRepository refreshTokenRepository;
 	
 	private final JWTService jwtService;
+	
+	private final VerificationTokenService verificationTokenService;
 	
 	private final AuthMapper authMapper;
 
@@ -59,7 +64,13 @@ public class AuthServiceImpl implements AuthService{
 		AuthUser authUser = buildAuthUserWithDefaultRole(registerRequest);
 	    AuthUser savedUser = authUserRepository.save(authUser);
 	    
+	    //Create Verification  Token
+	    VerificationToken verificationToken= verificationTokenService.createVerificationToken(savedUser , TokenPurpose.ACCOUNT_VERIFICATION);
 	    
+	    //Send verification email
+	    verificationTokenService.sendVerificationEmail(verificationToken);
+	    
+	   
 	     
 	    
 	    RefreshToken refreshToken = createAndSaveRefreshToken(savedUser , registerRequest.getIpAddress() , registerRequest.getUserAgent());

--- a/src/main/java/com/finscope/fraudscope/authentication/verification/enums/TokenPurpose.java
+++ b/src/main/java/com/finscope/fraudscope/authentication/verification/enums/TokenPurpose.java
@@ -1,0 +1,33 @@
+package com.finscope.fraudscope.authentication.verification.enums;
+
+public enum TokenPurpose {
+    ACCOUNT_VERIFICATION(
+        "Account Verification",
+        "Please verify your account by clicking the link below.",
+        "/api/auth/verify"
+    ),
+    PASSWORD_RESET(
+        "Password Reset",
+        "You requested a password reset. Click the link below to reset your password.",
+        "/api/auth/reset-password"
+    ),
+    EMAIL_CHANGE(
+        "Email Change",
+        "Please confirm your new email address by clicking the link below.",
+        "/api/auth/change-email"
+    );
+
+    private final String title;
+    private final String description;
+    private final String path;
+
+    TokenPurpose(String title, String description, String path) {
+        this.title = title;
+        this.description = description;
+        this.path = path;
+    }
+
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public String getPath() { return path; }
+}

--- a/src/main/java/com/finscope/fraudscope/authentication/verification/enums/TokenStatus.java
+++ b/src/main/java/com/finscope/fraudscope/authentication/verification/enums/TokenStatus.java
@@ -1,0 +1,11 @@
+package com.finscope.fraudscope.authentication.verification.enums;
+
+public enum TokenStatus  {
+
+	ACTIVE , 
+	USED , 
+	EXPIRED
+	
+	
+	
+}

--- a/src/main/java/com/finscope/fraudscope/authentication/verification/token/controller/VerificationController.java
+++ b/src/main/java/com/finscope/fraudscope/authentication/verification/token/controller/VerificationController.java
@@ -1,0 +1,35 @@
+package com.finscope.fraudscope.authentication.verification.token.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.finscope.fraudscope.authentication.verification.token.service.VerificationTokenService;
+import com.finscope.fraudscope.common.response.ApiResponse;
+import com.finscope.fraudscope.common.response.ErrorDetails;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class VerificationController {
+	
+	private final VerificationTokenService verificationTokenService;
+
+	@GetMapping("/verify")
+	public ResponseEntity<ApiResponse<?>> verifyAccount(@RequestParam String token) {
+		try {
+			verificationTokenService.verifyAccount(token);
+			return ResponseEntity.ok(ApiResponse.ok("Your account has been successfully activated!"));
+
+		} catch (RuntimeException e) {
+			ErrorDetails error = new ErrorDetails(e.getMessage(), "token", "TOKEN_INVALID");
+			return ResponseEntity.badRequest().body(ApiResponse.badRequest(error));
+		}
+
+	}
+
+}

--- a/src/main/java/com/finscope/fraudscope/authentication/verification/token/entity/VerificationToken.java
+++ b/src/main/java/com/finscope/fraudscope/authentication/verification/token/entity/VerificationToken.java
@@ -1,0 +1,47 @@
+package com.finscope.fraudscope.authentication.verification.token.entity;
+
+import java.time.LocalDateTime;
+
+import com.finscope.fraudscope.authentication.entity.AuthUser;
+import com.finscope.fraudscope.authentication.verification.enums.TokenPurpose;
+import com.finscope.fraudscope.authentication.verification.enums.TokenStatus;
+import com.finscope.fraudscope.common.audit.AuditBase;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "verification_tokens")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class VerificationToken extends AuditBase {
+
+	@Column(name = "verification_token", nullable = false, unique = true)
+	private String verificationToken;
+
+	@Enumerated(EnumType.STRING)
+	private TokenPurpose tokenPurpose;
+
+	@OneToOne(targetEntity = AuthUser.class, fetch = FetchType.EAGER)
+	@JoinColumn(name = "auth_user_id", nullable = false)
+	private AuthUser authUser;
+
+	@Enumerated(EnumType.STRING)
+	private TokenStatus tokenStatus;
+
+	@Column(name = "expiry_date_time", nullable = false)
+	private LocalDateTime expiryDateTime;
+
+}

--- a/src/main/java/com/finscope/fraudscope/authentication/verification/token/repository/VerificationTokenRepository.java
+++ b/src/main/java/com/finscope/fraudscope/authentication/verification/token/repository/VerificationTokenRepository.java
@@ -1,0 +1,14 @@
+package com.finscope.fraudscope.authentication.verification.token.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.finscope.fraudscope.authentication.verification.token.entity.VerificationToken;
+
+@Repository
+public interface VerificationTokenRepository extends JpaRepository<VerificationToken, Long> {
+
+	Optional<VerificationToken> findByVerificationToken(String token);
+}

--- a/src/main/java/com/finscope/fraudscope/authentication/verification/token/service/VerificationTokenService.java
+++ b/src/main/java/com/finscope/fraudscope/authentication/verification/token/service/VerificationTokenService.java
@@ -1,0 +1,14 @@
+package com.finscope.fraudscope.authentication.verification.token.service;
+
+import com.finscope.fraudscope.authentication.entity.AuthUser;
+import com.finscope.fraudscope.authentication.verification.enums.TokenPurpose;
+import com.finscope.fraudscope.authentication.verification.token.entity.VerificationToken;
+
+public interface VerificationTokenService {
+	VerificationToken createVerificationToken(AuthUser authUser, TokenPurpose tokenPurpose);
+	
+	void sendVerificationEmail(VerificationToken verificationToken);
+
+	void verifyAccount(String token);
+
+}

--- a/src/main/java/com/finscope/fraudscope/authentication/verification/token/service/impl/VerificationTokenServiceImpl.java
+++ b/src/main/java/com/finscope/fraudscope/authentication/verification/token/service/impl/VerificationTokenServiceImpl.java
@@ -1,0 +1,72 @@
+package com.finscope.fraudscope.authentication.verification.token.service.impl;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.finscope.fraudscope.authentication.entity.AuthUser;
+import com.finscope.fraudscope.authentication.repository.AuthUserRepository;
+import com.finscope.fraudscope.authentication.verification.enums.TokenPurpose;
+import com.finscope.fraudscope.authentication.verification.enums.TokenStatus;
+import com.finscope.fraudscope.authentication.verification.token.entity.VerificationToken;
+import com.finscope.fraudscope.authentication.verification.token.repository.VerificationTokenRepository;
+import com.finscope.fraudscope.authentication.verification.token.service.VerificationTokenService;
+import com.finscope.fraudscope.common.notification.EmailService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class VerificationTokenServiceImpl implements VerificationTokenService {
+
+	@Value("${verification.token.expiration-minutes}")
+	private int expiration;
+
+	private final VerificationTokenRepository verificationTokenRepository;
+
+	private final EmailService emailService;
+
+	private final AuthUserRepository authUserRepository;
+
+	@Override
+	public VerificationToken createVerificationToken(AuthUser authUser, TokenPurpose tokenPurpose) {
+		VerificationToken token = new VerificationToken();
+		token.setVerificationToken(UUID.randomUUID().toString());
+		token.setAuthUser(authUser);
+		token.setExpiryDateTime(LocalDateTime.now().plusMinutes(expiration));
+		token.setTokenPurpose(tokenPurpose);
+		token.setTokenStatus(TokenStatus.ACTIVE);
+
+		return verificationTokenRepository.save(token);
+	}
+
+	@Override
+	public void sendVerificationEmail(VerificationToken verificationToken) {
+
+		emailService.sendVerificationEmail(verificationToken);
+
+	}
+
+	@Override
+	public void verifyAccount(String token) {
+		VerificationToken verificationToken = verificationTokenRepository.findByVerificationToken(token)
+				.orElseThrow(() -> new RuntimeException("Token not found or invalid."));
+
+		if (verificationToken.getTokenStatus() == TokenStatus.ACTIVE
+				&& verificationToken.getExpiryDateTime().isAfter(LocalDateTime.now())) {
+
+			AuthUser user = verificationToken.getAuthUser();
+			user.setEnabled(true); // Activate user!
+			authUserRepository.save(user);
+
+			verificationToken.setTokenStatus(TokenStatus.USED);
+			verificationTokenRepository.save(verificationToken);
+
+		} else {
+			throw new RuntimeException("Token has expired or already been used.");
+		}
+	}
+
+}

--- a/src/main/java/com/finscope/fraudscope/common/bootstrap/DotenvInitializer.java
+++ b/src/main/java/com/finscope/fraudscope/common/bootstrap/DotenvInitializer.java
@@ -11,6 +11,8 @@ public class DotenvInitializer implements ApplicationContextInitializer<Configur
         System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
         System.setProperty("JWT_SECRET_KEY", dotenv.get("JWT_SECRET_KEY"));
-        System.out.println("✔ Dotenv environment variables loaded before Spring starts.");
+        System.setProperty("MAIL_FROM", dotenv.get("MAIL_FROM"));
+        System.setProperty("MAIL_PASSWORD", dotenv.get("MAIL_PASSWORD"));
+        System.out.println(" Dotenv environment variables loaded before Spring starts.");
     }
 }

--- a/src/main/java/com/finscope/fraudscope/common/notification/EmailService.java
+++ b/src/main/java/com/finscope/fraudscope/common/notification/EmailService.java
@@ -1,0 +1,66 @@
+package com.finscope.fraudscope.common.notification;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import com.finscope.fraudscope.authentication.verification.enums.TokenPurpose;
+import com.finscope.fraudscope.authentication.verification.token.entity.VerificationToken;
+
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String fromMail;
+
+    public void sendVerificationEmail(VerificationToken verificationToken) {
+    	
+    	String toEmail = verificationToken.getAuthUser().getEmail();
+    	TokenPurpose purpose = verificationToken.getTokenPurpose();
+    	
+        String subject = purpose.getTitle();
+        String path = purpose.getPath();
+        String message = purpose.getDescription();
+        sendEmail(toEmail, verificationToken.getVerificationToken(), subject, path, message);
+    }
+
+    private void sendEmail(String toEmail, String token, String subject, String path, String message) {
+        try {
+            String actionUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
+                    .path(path)
+                    .queryParam("token", token)
+                    .toUriString();
+
+            String content = """
+                <div style="text-align: center;">
+                    <h3>%s</h3>
+                    <p>%s</p>
+                    <a href="%s" style="padding:10px; background-color:blue; color:white;">Verify Email</a>
+                    <p>If you can't click, copy this URL: %s</p>
+                </div>
+                """.formatted(subject, message, actionUrl, actionUrl);
+
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true);
+
+            helper.setTo(toEmail);
+            helper.setSubject(subject);
+            helper.setFrom("no-reply."+fromMail);
+            helper.setText(content, true);
+
+            mailSender.send(mimeMessage);
+        } catch (Exception e) {
+            System.err.println("Failed to send email: " + e.getMessage());
+        }
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,19 @@ spring:
     basename: currency_type,account_type,transaction_status,transaction_type,approval_status
     encoding: UTF-8
     fallback-to-system-locale: false
-
+#SMTP  
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_FROM}
+    password: ${MAIL_PASSWORD}
+    protocol: smtp
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 # JWT 
 jwt:
   secret:
@@ -45,5 +57,7 @@ logging:
   level:
     org.springframework.boot.context.config: DEBUG
 
-
+verification:
+  token:
+    expiration-minutes: 240 # 4 hour
 


### PR DESCRIPTION
…ponse structure

- Added public /api/auth/verify endpoint for account activation via token
- Integrated ApiResponse and ErrorDetails for consistent API responses
- Updated SecurityConfig to allow permitAll for registration and verification endpoints
- Integrated SMTP-based email sending for verification mails
- Ensured tokens are single-use, expire-aware, and properly update user status